### PR TITLE
Fix: Resolve database connection error in production

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -33,9 +33,6 @@ module.exports = {
 } else {
   pool = new Pool({
     connectionString: process.env.DATABASE_URL,
-    ssl: {
-      rejectUnauthorized: false,
-    },
   })
   module.exports = {
     query: (text, params) => pool.query(text, params),


### PR DESCRIPTION
Removes the SSL configuration from the production database connection options. The previous configuration was causing a `getaddrinfo ENOTFOUND` error when deploying to Render. This change aligns the production environment with the expected connection settings, allowing the application to connect to the database successfully.